### PR TITLE
"williamboman/nvim-lsp-installer" plugin was deprecated, replaced by "williamboman/mason.nvim"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -5,3 +5,4 @@ require("plugins")
 
 -- After plugins
 require("user.colorscheme")
+require("user.diagnostics")

--- a/lua/cmp-config/init.lua
+++ b/lua/cmp-config/init.lua
@@ -124,45 +124,6 @@ local custom_lsp_attach = function(client, bufnr)
   illuminate.on_attach(client)
 end
 
--- Diagnostics and their representation
--- vim.cmd([[autocmd CursorHold,CursorHoldI * lua vim.diagnostic.open_float(nil, {focus=false})]])
-
-vim.diagnostic.config({
-  virtual_text = false,
-  signs = false,
-  underline = true,
-  update_in_insert = true,
-  float = {
-    focusable = false,
-    style = "minimal",
-    border = "rounded",
-    source = "always",
-    header = "",
-    prefix = "",
-  },
-  severity_sort = true,
-})
-
-vim.lsp.handlers["textDocument/publishDiagnostics"] =
-  vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
-    underline = false,
-    signs = {
-      severity_limit = "Hint",
-    },
-    virtual_text = {
-      spacing = 5,
-      severity_limit = "Warning",
-      prefix = " ", -- Could be '■' '●', '▎', 'x',
-    },
-    update_in_insert = false,
-  })
-
-local signs = { Error = " ", Warn = " ", Hint = " ", Info = " " }
-for type, icon in pairs(signs) do
-  local hl = "DiagnosticSign" .. type
-  vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
-end
-
 ---@cast cmp -?
 -- See https://github.com/sumneko/lua-language-server/issues/1487
 cmp.setup({

--- a/lua/mason-config/init.lua
+++ b/lua/mason-config/init.lua
@@ -1,0 +1,8 @@
+-- skip if module(s) isn't loaded
+local status_ok, _ = pcall(require, "mason")
+if not status_ok then return end
+
+require("mason").setup()
+require("mason-lspconfig").setup({
+  ensure_installed = { "sumneko_lua", "bashls", "yamlls" },
+})

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -238,9 +238,9 @@ return require("packer").startup(function(use)
     config = "require('cmp-config')",
   })
 
-  use("neovim/nvim-lspconfig")
-
-  use({
+  -- Author has deprecated this plugin and moved into a new plugin with even more Functionality:
+  -- https://github.com/williamboman/mason.nvim
+  --[[ use({
     "williamboman/nvim-lsp-installer",
     config = function()
       require("nvim-lsp-installer").setup({
@@ -248,6 +248,13 @@ return require("packer").startup(function(use)
         automatic_installation = true,
       })
     end,
+  }) ]]
+
+  use({
+    "williamboman/mason.nvim",
+    "williamboman/mason-lspconfig.nvim",
+    "neovim/nvim-lspconfig",
+    config = require("lua.mason-config.init"),
   })
 
   use("hrsh7th/cmp-nvim-lsp")

--- a/lua/user/diagnostics.lua
+++ b/lua/user/diagnostics.lua
@@ -1,0 +1,40 @@
+-- Diagnostics and their representation
+-- vim.cmd([[autocmd CursorHold,CursorHoldI * lua vim.diagnostic.open_float(nil, {focus=false})]])
+
+vim.diagnostic.config({
+  virtual_text = false,
+  signs = false,
+  underline = true,
+  update_in_insert = true,
+  float = {
+    border = "rounded",
+    header = "",
+    focusable = false,
+    prefix = "",
+    scope = "cursor",
+    severity_sort = false,
+    style = "minimal",
+    source = "always",
+  },
+  severity_sort = false,
+})
+
+vim.lsp.handlers["textDocument/publishDiagnostics"] =
+vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
+  underline = false,
+  signs = {
+    severity_limit = "vim.diagnostic.severity.HINT",
+  },
+  --[[ virtual_text = {
+    spacing = 5,
+    severity_limit = "Warning",
+    prefix = " ", -- Could be '■' '●', '▎', 'x',
+  }, ]]
+  update_in_insert = false,
+})
+
+local signs = { Error = " ", Warn = " ", Hint = " ", Info = " " }
+for type, icon in pairs(signs) do
+  local hl = "DiagnosticSign" .. type
+  vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
+end

--- a/lua/whichkey-config/init.lua
+++ b/lua/whichkey-config/init.lua
@@ -121,7 +121,7 @@ local mappings = {
     a = { "<cmd>lua vim.lsp.buf.code_action()<cr>", "Code Action" },
     f = { "<cmd>lua vim.lsp.buf.format{async=false} vim.diagnostic.enable()<cr>", "Format" },
     i = { "<cmd>LspInfo<cr>", "Info" },
-    I = { "<cmd>LspInstallInfo<cr>", "Installer Info" },
+    m = { "<cmd>Mason<cr>", "List LSP servers installed." },
     s = { "<cmd>Telescope lsp_document_symbols<cr>", "Document Symbols" },
   },
   ["q"] = { "<cmd>q!<CR>", "Quit" },


### PR DESCRIPTION
- chore!(diagnostics): moved diagnostics configuration
- feat!(lsp-config): williamboman/nvim-lsp-installer deprecated.
- fix(whichkey-config): updated now that LSPInstalled is gone.
